### PR TITLE
Add security emoji to README 🔐

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Amazon Corretto Crypto Provider
+# Amazon Corretto Crypto Provider 🔐
 The Amazon Corretto Crypto Provider (ACCP) is a collection of high-performance cryptographic implementations exposed via the standard [JCA/JCE](https://docs.oracle.com/en/java/javase/11/security/java-cryptography-architecture-jca-reference-guide.html) interfaces.
 This means that it can be used as a drop in replacement for many different Java applications.
 (Differences from the default OpenJDK implementations are [documented here](./DIFFERENCES.md).)


### PR DESCRIPTION
This PR adds a lock emoji to the README title to enhance the visual security appeal of our crypto provider.

Changes:
- Added 🔐 emoji to the main title
- No functional changes

This is a silly but harmless cosmetic improvement that makes our README more visually appealing while staying on-brand with our cryptographic focus.